### PR TITLE
Enable maximum file size configuration and add exception handling for the basic operations

### DIFF
--- a/src/fileyard/main.clj
+++ b/src/fileyard/main.clj
@@ -105,15 +105,16 @@
     (catch NumberFormatException nfe
       false)))
 
-(defn start [path port]
-  (server/run-server (handler path) {:port port})
+(defn start [path port max-file-size]
+  (server/run-server (handler path) {:port port
+                                     :max-body (or max-file-size 32000000)})
   (println "Fileyard is up"))
 
 (defn -main [& args]
-  (let [[path port] args]
+  (let [[path port max-file-size] args]
     (cond
       (not (and path port))
-      (println "Usage: give storage path and port")
+      (println "Usage: give storage path and port. Optional: max file size (default 32MB).")
 
       (not (check-path path))
       (println "Given path is not a writable directory: " path)
@@ -122,4 +123,4 @@
       (println "Given port is not a unprivileged port: " port)
 
       :default
-      (start (io/file path) (Integer/valueOf port)))))
+      (start (io/file path) (Integer/valueOf port) (when max-file-size (Integer/valueOf max-file-size))))))

--- a/src/fileyard/main.clj
+++ b/src/fileyard/main.clj
@@ -83,15 +83,18 @@
 
 (defn handler [storage-path]
   (fn [{:keys [request-method] :as req}]
-    (cond
-      (= request-method :post)
-      (post-file storage-path req)
+      (try
+        (cond
+          (= request-method :post)
+          (post-file storage-path req)
 
-      (= request-method :get)
-      (get-file storage-path req)
+          (= request-method :get)
+          (get-file storage-path req)
 
-      :default
-      {:status 400 :body "Unrecognized request. Either POST or GET a file."})))
+          :default
+          {:status 400 :body "Unrecognized request. Either POST or GET a file."})
+        (catch Exception e
+          (println "An exception occurred when handling the request: " request-method ": " e)))))
 
 
 (defn check-path [path]


### PR DESCRIPTION
The HTTP Kits server has the max body size of around 8,3MB by default. In most cases this is not enough, so this PR enables the users to configure the maximum upload file size or just use the default value of 32MB. 

In addition, the basic POST and GET operations are wrapped in a try-catch clause in order to log the occurred exceptions  and recover from them.

Also it would be good to add better response handling for the client. For some reason when uploading a file that's above the HTTP Kits max body size, the HTTP status code 413 is handled in an odd way. Therefore the entire response should be logged, when the response is considered erroneous. 